### PR TITLE
Fix: CrossOrigin

### DIFF
--- a/src/main/java/com/gdsc/mbti/controller/MbtiController.java
+++ b/src/main/java/com/gdsc/mbti/controller/MbtiController.java
@@ -14,6 +14,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/mbti")
 @RequiredArgsConstructor
+@CrossOrigin
 public class MbtiController {
 
     private final MbtiService service;


### PR DESCRIPTION
mbti controller 에서 cors 에러를 해결